### PR TITLE
feat: premium login bypass for proxy-forwarded accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 - Config/messages: blocs `premium.*`.
 - CI: artefact `Faskin-0.1.0-SNAPSHOT.jar`.
 - Détection premium via forwarding (UUID + textures) — sans bypass.
+- T2.3: Bypass /login pour comptes premium (PROXY_SAFE), sessions & états, logs/guards.
 ### Changed
-- Bump version plugin à `0.1.0`.
+- Bump version plugin à `0.1.0-SNAPSHOT`.
 
 ## [0.0.10] - 2025-08-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ Plugin unifié Spigot 1.21 / Java 21 :
 ## Sessions par IP
 - Voir `login.allow_ip_session` et `session_minutes`.
 
-## Mode PROXY_SAFE recommandé
+## Activer le bypass premium (Étape 2)
 Faskin privilégie un proxy en **online-mode** avec [player information forwarding](https://docs.papermc.io/velocity/player-information-forwarding/) activé. Cela permet de transmettre UUID, IP et propriétés signées pour un auto-login premium sécurisé. Sans forwarding, aucun bypass n'est effectué. Réfs : [FastLogin](https://www.spigotmc.org/resources/fastlogin.14153/), [Velocity](https://docs.papermc.io/velocity/player-information-forwarding/).
 
-## Pré-requis Étape 2 (PROXY_SAFE)
-Pour prouver qu'un joueur est premium, le proxy doit transférer son identité complète au backend.
+Exemple **Velocity** :
 
 ```toml
 # velocity.toml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.gradleup.shadow") version "9.0.2" // Shadow 9, compatible Gradle 9
 }
 
-version = "0.1.0"
+version = "0.1.0-SNAPSHOT"
 
 java {
     toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,6 +32,8 @@ Permettre aux comptes **premium vérifiés** d’entrer **sans mot de passe**, t
    - Sinon → `LOGIN_REQUIRED` (flux Étape 1)
 3) `AUTHENTICATED` (création/renouvellement session IP si activée)
 
+Flux simplifié : `JOINING → PRE_AUTH → (PREMIUM_SAFE ? BYPASS : LOGIN_REQUIRED) → AUTHENTICATED`.
+
 ### Détection premium (règles)
 - Source: données de forwarding du proxy (UUID online + properties).
 - Inspection de `PlayerProfile#getTextures()` au `PlayerJoinEvent` : absence de skin ou profil non signé ⇒ pas de preuve premium.
@@ -119,4 +121,4 @@ _Notes sources_ :
 - Mettre à jour `README.md` avec un encart **“Mode PROXY_SAFE recommandé”** + extrait de config Velocity (`player-info-forwarding`) pour éviter les faux positifs et sécuriser le bypass.
 - [x] T2.1 — Base auto-login premium
 - [x] T2.2 — Détection premium via forwarding (UUID + textures)
-- [ ] T2.3 — Intégration bypass `/login`
+- [x] T2.3 — Intégration bypass `/login`

--- a/src/main/java/com/faskin/auth/listeners/JoinQuitListener.java
+++ b/src/main/java/com/faskin/auth/listeners/JoinQuitListener.java
@@ -36,6 +36,7 @@ public final class JoinQuitListener implements Listener {
 
             if (!exists) {
                 Bukkit.getScheduler().runTask(plugin, () -> {
+                    if (plugin.services().getState(p.getUniqueId()) == PlayerAuthState.AUTHENTICATED) return;
                     if (chatOnJoin) p.sendMessage(plugin.messages().prefixed("reminder_chat"));
                     plugin.getTimeouts().schedule(p);
                     p.sendMessage(plugin.messages().prefixed("must_register"));
@@ -53,6 +54,7 @@ public final class JoinQuitListener implements Listener {
 
                     if (ipMatch && within) {
                         Bukkit.getScheduler().runTask(plugin, () -> {
+                            if (plugin.services().getState(p.getUniqueId()) == PlayerAuthState.AUTHENTICATED) return;
                             plugin.services().setState(p.getUniqueId(), PlayerAuthState.AUTHENTICATED);
                             p.sendMessage(plugin.messages().prefixed("login_ok"));
                         });
@@ -62,6 +64,7 @@ public final class JoinQuitListener implements Listener {
             }
 
             Bukkit.getScheduler().runTask(plugin, () -> {
+                if (plugin.services().getState(p.getUniqueId()) == PlayerAuthState.AUTHENTICATED) return;
                 if (chatOnJoin) p.sendMessage(plugin.messages().prefixed("reminder_chat"));
                 plugin.services().setState(p.getUniqueId(), PlayerAuthState.REGISTERED_UNAUTH);
                 plugin.getTimeouts().schedule(p);

--- a/src/main/java/com/faskin/auth/listeners/PremiumLoginListener.java
+++ b/src/main/java/com/faskin/auth/listeners/PremiumLoginListener.java
@@ -15,12 +15,24 @@ public final class PremiumLoginListener implements Listener {
 
     @EventHandler
     public void onPlayerLogin(PlayerLoginEvent e) {
-        // placeholder for future use
+        // no-op: evaluation happens on join when profile is complete
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent e) {
-        PremiumEvaluation eval = plugin.services().premiumDetector().evaluateJoin(e.getPlayer());
-        plugin.getServer().getPluginManager().callEvent(new PremiumEvaluatedEvent(e.getPlayer(), eval));
+        var player = e.getPlayer();
+        PremiumEvaluation eval = plugin.services().premiumDetector().evaluateJoin(player);
+        plugin.getServer().getPluginManager().callEvent(new PremiumEvaluatedEvent(player, eval));
+
+        if (eval == PremiumEvaluation.PREMIUM_SAFE && plugin.configs().premiumSkipPassword()) {
+            player.sendMessage(plugin.messages().prefixed("premium.bypass-start"));
+            plugin.services().authBypass().markAuthenticated(player.getUniqueId(), player.getName(), player.getUniqueId().toString(), plugin.configs().premiumMode());
+            player.sendMessage(plugin.messages().prefixed("premium.bypass-ok"));
+        } else if (plugin.configs().premiumRequireIpForwarding()) {
+            String reason = plugin.messages().raw("premium.need-forwarding");
+            player.sendMessage(plugin.messages().prefixed("premium.need-forwarding"));
+            player.sendMessage(plugin.messages().prefixed("premium.bypass-refused").replace("{reason}", reason));
+            plugin.getLogger().warning("Premium bypass refused for " + player.getName() + ": need-forwarding");
+        }
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -43,8 +43,9 @@ admin_stats_lines:
   - "&7Online non-AUTH: &f{ONLINE_NONAUTH}"
 
 premium:
+  bypass-start: "&7Vérification du statut premium..."
   bypass-ok: "&aConnexion premium vérifiée. Authentifié automatiquement."
   bypass-refused: "&cBypass premium refusé: {reason}."
   unlink-ok: "&eTon compte premium est dissocié. Mot de passe requis au prochain login."
-  forwarding-missing: "&cProxy mal configuré (player-info-forwarding). Bypass premium indisponible."
+  need-forwarding: "&cProxy mal configuré (player-info-forwarding)."
   no-textures: "&eProfil premium non prouvé (textures absentes)."

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -20,3 +20,11 @@ help_lines:
   - "&f/logout &7: log out"
   - "&f/changepassword <old> <new> <confirm> &7: change password"
   - "&f/faskin reload|status [player] &7: admin"
+
+premium:
+  bypass-start: "&7Checking premium status..."
+  bypass-ok: "&aPremium login verified. Auto-authenticated."
+  bypass-refused: "&cPremium bypass refused: {reason}."
+  unlink-ok: "&eYour premium account is unlinked. Password required next login."
+  need-forwarding: "&cProxy misconfigured (player-info-forwarding)."
+  no-textures: "&ePremium profile not proven (textures missing)."


### PR DESCRIPTION
## Summary
- auto-authenticate premium-safe players and update sessions
- warn when player-info-forwarding is missing
- document premium bypass configuration and update roadmap

## Testing
- `gradle clean build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a08c0b5ae08324a15e627bdc85b6c7