### PR TITLE
feat: add premium status and unlink commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.0] - T2.5
+- Commandes premium (status/unlink), tab-complete, i18n, DB async
+
 ## [0.1.0] - T2.4
 - UX/i18n: messages premium complets (forwarding/skins/fallback)
 - Metrics: compteurs bypass & raisons, temps PRE_AUTH

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Plugin unifié Spigot 1.21 / Java 21 :
 - `/faskin unlock <player>` : reset failed_count + locked_until.
 - `/faskin stats` : comptes totaux, locks actifs, online AUTH / non-AUTH.
 
+## Commandes premium
+- `/premium status [player]` : statut premium (self/admin). Perms : `faskin.premium.status`, `faskin.premium.status.other`.
+- `/premium unlink [player]` : dissocie le mode premium → retour au mot de passe. Perms : `faskin.premium.unlink.self`, `faskin.premium.unlink.other`.
+  *Tab-complete propose joueurs en ligne et derniers comptes premium vus.*
+
+### Pré-requis proxy
+Le bypass premium n’existe que si le proxy est en **online-mode** avec **player-info-forwarding** (`modern`) et secret partagé. Sans cela, Faskin n’accorde aucun bypass.
+
 ## i18n & couleurs
 - `messages_locale` ou `messages.locale` pour choisir la langue (`messages.yml` / `messages_<locale>.yml`).
 - Codes couleur `&` convertis via l’API Spigot.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,7 +81,7 @@ session:
 * [ ] `AuthBypassService` (marque AUTHENTICATED, crée session si besoin)
 * [ ] Listeners `AsyncPlayerPreLoginEvent`/`PlayerLoginEvent` (intégration)
 * [ ] Config & messages (nouveaux blocs YAML + i18n)
-* [ ] Commandes `/premium status|unlink` (+ tab-complete, perms)
+* [x] Commandes `/premium status|unlink` (+ tab-complete, perms)
 * [ ] Logs & métriques
 * [ ] Doc README: guide proxy (online-mode, forwarding) + exemples
 * [ ] Tests manuels (voir Validation)
@@ -132,4 +132,6 @@ _Notes sources_ :
 - [x] T2.1 — Base auto-login premium
 - [x] T2.2 — Détection premium via forwarding (UUID + textures)
 - [x] T2.3 — Intégration bypass `/login`
-- [ ] T2.4 — Finitions Étape 2 (UX, métriques, garde-fous)
+- [x] T2.4 — Finitions Étape 2 (UX, métriques, garde-fous)
+- [x] T2.5 — Commandes premium (status/unlink, perms)
+- [ ] T2.6 — Validation finale & sécurité

--- a/src/main/java/com/faskin/auth/FaskinPlugin.java
+++ b/src/main/java/com/faskin/auth/FaskinPlugin.java
@@ -1,6 +1,8 @@
 package com.faskin.auth;
 
 import com.faskin.auth.commands.*;
+import com.faskin.auth.command.PremiumCommand;
+import com.faskin.auth.tab.PremiumTabCompleter;
 import com.faskin.auth.config.ConfigManager;
 import com.faskin.auth.core.AuthServiceRegistry;
 import com.faskin.auth.core.InMemoryAccountRepository;
@@ -80,6 +82,9 @@ public final class FaskinPlugin extends JavaPlugin {
         bind("login", new LoginCommand(this));
         bind("logout", new LogoutCommand(this));
         bind("changepassword", new ChangePasswordCommand(this));
+        bind("premium", new PremiumCommand(this));
+        PluginCommand pc = getCommand("premium");
+        if (pc != null) pc.setTabCompleter(new PremiumTabCompleter());
 
         // Rappel périodique (ActionBar/Chat)
         if (getConfig().getBoolean("reminder.enabled", true)) {

--- a/src/main/java/com/faskin/auth/command/PremiumCommand.java
+++ b/src/main/java/com/faskin/auth/command/PremiumCommand.java
@@ -1,0 +1,46 @@
+package com.faskin.auth.command;
+
+import com.faskin.auth.FaskinPlugin;
+import com.faskin.auth.command.sub.PremiumSub;
+import com.faskin.auth.command.sub.PremiumStatusSub;
+import com.faskin.auth.command.sub.PremiumUnlinkSub;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public final class PremiumCommand implements CommandExecutor {
+    private final FaskinPlugin plugin;
+    private final Map<String, PremiumSub> subs = new HashMap<>();
+
+    public PremiumCommand(FaskinPlugin plugin) {
+        this.plugin = plugin;
+        subs.put("status", new PremiumStatusSub(plugin));
+        subs.put("unlink", new PremiumUnlinkSub(plugin));
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("faskin.premium.base")) {
+            sender.sendMessage(plugin.messages().prefixed("premium.error.no-permission"));
+            return true;
+        }
+        if (args.length == 0) {
+            sender.sendMessage(plugin.messages().prefixed("premium.error.no-target"));
+            return true;
+        }
+        String subName = args[0].toLowerCase(Locale.ROOT);
+        PremiumSub sub = subs.get(subName);
+        if (sub == null) {
+            sender.sendMessage(plugin.messages().prefixed("premium.error.no-target"));
+            return true;
+        }
+        String[] subArgs = Arrays.copyOfRange(args, 1, args.length);
+        sub.execute(sender, subArgs);
+        return true;
+    }
+}

--- a/src/main/java/com/faskin/auth/command/sub/PremiumStatusSub.java
+++ b/src/main/java/com/faskin/auth/command/sub/PremiumStatusSub.java
@@ -1,0 +1,104 @@
+package com.faskin.auth.command.sub;
+
+import com.faskin.auth.FaskinPlugin;
+import com.faskin.auth.core.AccountRepository;
+import com.faskin.auth.tab.PremiumTabCompleter;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public final class PremiumStatusSub implements PremiumSub {
+    private final FaskinPlugin plugin;
+
+    public PremiumStatusSub(FaskinPlugin plugin) { this.plugin = plugin; }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            if (!(sender instanceof Player p)) {
+                sender.sendMessage(plugin.messages().prefixed("premium.error.no-target"));
+                return;
+            }
+            if (!sender.hasPermission("faskin.premium.status")) {
+                sender.sendMessage(plugin.messages().prefixed("premium.error.no-permission"));
+                return;
+            }
+            PremiumTabCompleter.record(p.getName());
+            String key = p.getName().toLowerCase(Locale.ROOT);
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                AccountRepository repo = plugin.services().accounts();
+                var info = repo.getPremiumInfo(key).orElse(null);
+                var session = repo.getSessionMeta(key).orElse(null);
+                boolean prem = info != null && info.isPremium;
+                String mode = info != null && info.premiumMode != null ? info.premiumMode : "NONE";
+                String uuid = info != null && info.uuidOnline != null ? info.uuidOnline : "n/a";
+                String uuidShort = uuid.length() > 8 ? uuid.substring(0, 8) : uuid;
+                String verified = info != null && info.verifiedAtEpoch > 0
+                        ? DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault())
+                                .format(Instant.ofEpochSecond(info.verifiedAtEpoch))
+                        : "never";
+                String sessionState = "inactive";
+                long ttl = 0L;
+                if (plugin.configs().allowIpSession() && plugin.configs().sessionMinutes() > 0 && session != null) {
+                    long now = Instant.now().getEpochSecond();
+                    long diff = now - session.lastLoginEpoch;
+                    long ttlSec = plugin.configs().sessionMinutes() * 60L - diff;
+                    if (ttlSec > 0 && session.lastIp != null) {
+                        sessionState = "active";
+                        ttl = ttlSec;
+                    }
+                }
+                long finalTtl = ttl;
+                String finalSessionState = sessionState;
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    String prefix = plugin.messages().raw("prefix");
+                    boolean usePrefix = plugin.getConfig().getBoolean("messages.use_prefix", true);
+                    for (String line : plugin.messages().raw("premium.status-self").split("\\n")) {
+                        line = line.replace("{is_premium}", String.valueOf(prem))
+                                .replace("{mode}", mode)
+                                .replace("{uuid_online}", uuidShort)
+                                .replace("{verified_at}", verified)
+                                .replace("{session}", finalSessionState)
+                                .replace("{ttl}", String.valueOf(finalTtl));
+                        if (usePrefix) line = prefix + line;
+                        sender.sendMessage(ChatColor.translateAlternateColorCodes('&', line));
+                    }
+                });
+            });
+        } else {
+            if (!sender.hasPermission("faskin.premium.status.other")) {
+                sender.sendMessage(plugin.messages().prefixed("premium.error.no-permission"));
+                return;
+            }
+            String target = args[0];
+            PremiumTabCompleter.record(target);
+            String key = target.toLowerCase(Locale.ROOT);
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                AccountRepository repo = plugin.services().accounts();
+                var info = repo.getPremiumInfo(key).orElse(null);
+                boolean prem = info != null && info.isPremium;
+                String mode = info != null && info.premiumMode != null ? info.premiumMode : "NONE";
+                String uuid = info != null && info.uuidOnline != null ? info.uuidOnline : "n/a";
+                String uuidShort = uuid.length() > 8 ? uuid.substring(0, 8) : uuid;
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    String prefix = plugin.messages().raw("prefix");
+                    boolean usePrefix = plugin.getConfig().getBoolean("messages.use_prefix", true);
+                    for (String line : plugin.messages().raw("premium.status-other").split("\\n")) {
+                        line = line.replace("{player}", target)
+                                .replace("{is_premium}", String.valueOf(prem))
+                                .replace("{mode}", mode)
+                                .replace("{uuid_online}", uuidShort);
+                        if (usePrefix) line = prefix + line;
+                        sender.sendMessage(ChatColor.translateAlternateColorCodes('&', line));
+                    }
+                });
+            });
+        }
+    }
+}

--- a/src/main/java/com/faskin/auth/command/sub/PremiumSub.java
+++ b/src/main/java/com/faskin/auth/command/sub/PremiumSub.java
@@ -1,0 +1,7 @@
+package com.faskin.auth.command.sub;
+
+import org.bukkit.command.CommandSender;
+
+public interface PremiumSub {
+    void execute(CommandSender sender, String[] args);
+}

--- a/src/main/java/com/faskin/auth/command/sub/PremiumUnlinkSub.java
+++ b/src/main/java/com/faskin/auth/command/sub/PremiumUnlinkSub.java
@@ -1,0 +1,75 @@
+package com.faskin.auth.command.sub;
+
+import com.faskin.auth.FaskinPlugin;
+import com.faskin.auth.core.AccountRepository;
+import com.faskin.auth.core.PlayerAuthState;
+import com.faskin.auth.tab.PremiumTabCompleter;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Locale;
+
+public final class PremiumUnlinkSub implements PremiumSub {
+    private final FaskinPlugin plugin;
+
+    public PremiumUnlinkSub(FaskinPlugin plugin) { this.plugin = plugin; }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            if (!(sender instanceof Player p)) {
+                sender.sendMessage(plugin.messages().prefixed("premium.error.no-target"));
+                return;
+            }
+            if (!sender.hasPermission("faskin.premium.unlink.self")) {
+                sender.sendMessage(plugin.messages().prefixed("premium.error.no-permission"));
+                return;
+            }
+            PremiumTabCompleter.record(p.getName());
+            String key = p.getName().toLowerCase(Locale.ROOT);
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                AccountRepository repo = plugin.services().accounts();
+                var info = repo.getPremiumInfo(key).orElse(null);
+                if (info == null || !info.isPremium) {
+                    Bukkit.getScheduler().runTask(plugin, () ->
+                            sender.sendMessage(plugin.messages().prefixed("premium.unlink.not-premium")));
+                    return;
+                }
+                repo.updatePremiumInfo(key, false, null, null, 0L);
+                repo.updateLastLoginAndIp(key, null, 0L);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    plugin.services().setState(p.getUniqueId(), PlayerAuthState.REGISTERED_UNAUTH);
+                    p.sendMessage(plugin.messages().prefixed("premium.unlink.self-ok"));
+                });
+            });
+        } else {
+            if (!sender.hasPermission("faskin.premium.unlink.other")) {
+                sender.sendMessage(plugin.messages().prefixed("premium.error.no-permission"));
+                return;
+            }
+            String target = args[0];
+            PremiumTabCompleter.record(target);
+            String key = target.toLowerCase(Locale.ROOT);
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                AccountRepository repo = plugin.services().accounts();
+                var info = repo.getPremiumInfo(key).orElse(null);
+                if (info == null || !info.isPremium) {
+                    Bukkit.getScheduler().runTask(plugin, () ->
+                            sender.sendMessage(plugin.messages().prefixed("premium.unlink.not-premium")));
+                    return;
+                }
+                repo.updatePremiumInfo(key, false, null, null, 0L);
+                repo.updateLastLoginAndIp(key, null, 0L);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    Player online = Bukkit.getPlayerExact(target);
+                    if (online != null) {
+                        plugin.services().setState(online.getUniqueId(), PlayerAuthState.REGISTERED_UNAUTH);
+                    }
+                    plugin.getLogger().info("[Faskin/Premium] unlink by " + sender.getName() + " target=" + target);
+                    sender.sendMessage(plugin.messages().prefixed("premium.unlink.other-ok").replace("{player}", target));
+                });
+            });
+        }
+    }
+}

--- a/src/main/java/com/faskin/auth/tab/PremiumTabCompleter.java
+++ b/src/main/java/com/faskin/auth/tab/PremiumTabCompleter.java
@@ -1,0 +1,48 @@
+package com.faskin.auth.tab;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+
+public final class PremiumTabCompleter implements TabCompleter {
+    private static final int MAX = 25;
+    private static final LinkedHashSet<String> RECENTS = new LinkedHashSet<>();
+
+    public static void record(String name) {
+        synchronized (RECENTS) {
+            RECENTS.remove(name);
+            RECENTS.add(name);
+            while (RECENTS.size() > MAX) {
+                Iterator<String> it = RECENTS.iterator();
+                if (it.hasNext()) { it.next(); it.remove(); }
+            }
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args) {
+        List<String> out = new ArrayList<>();
+        if (args.length == 1) {
+            for (String opt : new String[]{"status","unlink"}) {
+                if (opt.startsWith(args[0].toLowerCase(Locale.ROOT))) out.add(opt);
+            }
+            return out;
+        }
+        if (args.length == 2) {
+            for (Player p : Bukkit.getOnlinePlayers()) out.add(p.getName());
+            synchronized (RECENTS) { out.addAll(RECENTS); }
+            String pref = args[1].toLowerCase(Locale.ROOT);
+            out.removeIf(n -> !n.toLowerCase(Locale.ROOT).startsWith(pref));
+            return out;
+        }
+        return out;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,9 +65,9 @@ reminder:
 premium:
   enabled: true
   mode: PROXY_SAFE            # PROXY_SAFE | SPIGOT_FALLBACK (pas de bypass en fallback)
-  skip_password: true         # bypass /login si PREMIUM_SAFE
+  skip_password: true         # bypass /login si PREMIUM_SAFE (doit rester true pour l'auto-login)
   auto_register: true         # création compte si absent lors d'un PREMIUM_SAFE
-  require_ip_forwarding: true # refuse bypass si le proxy ne transmet pas UUID/IP/skins
+  require_ip_forwarding: true # recommandé true ; sinon pas de bypass (proxy doit transmettre UUID/IP/skins)
   metrics: true               # expose métriques internes (log & /faskin stats)
   debug: false                # logs détaillés (à n'activer qu'en test)
 # Forwarding modern recommandé : Velocity `player-info-forwarding-mode="modern"`.

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -59,4 +59,16 @@ premium:
     no-textures: "profil sans textures signées (skins non transmis)."
     fallback-mode: "mode SPIGOT_FALLBACK: bypass désactivé."
     unknown: "identité premium non prouvée."
-  unlink-ok: "&eTon compte premium est dissocié. Mot de passe requis au prochain login."
+  status-self:
+    - "&7Premium: &e{is_premium}&7 | Mode: &e{mode}"
+    - "&7UUID online: &e{uuid_online}&7 | Vérif: &e{verified_at}"
+    - "&7Session IP: &e{session}&7 (TTL: &e{ttl}&7)"
+  status-other:
+    - "&7{player}: premium=&e{is_premium}&7, mode=&e{mode}&7, uuid=&e{uuid_online}"
+  unlink:
+    self-ok: "&eDissociation premium effectuée. Mot de passe requis au prochain login."
+    other-ok: "&e{player} dissocié du mode premium."
+    not-premium: "&7Aucune dissociation: le compte n'est pas premium."
+  error:
+    no-target: "&cJoueur introuvable."
+    no-permission: "&cPermission insuffisante."

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -30,7 +30,19 @@ premium:
     no-textures: "profile without signed textures (skins not forwarded)."
     fallback-mode: "SPIGOT_FALLBACK mode: bypass disabled."
     unknown: "premium identity not proven."
-  unlink-ok: "&eYour premium account is unlinked. Password required next login."
+  status-self:
+    - "&7Premium: &e{is_premium}&7 | Mode: &e{mode}"
+    - "&7UUID online: &e{uuid_online}&7 | Verified: &e{verified_at}"
+    - "&7IP session: &e{session}&7 (TTL: &e{ttl}&7)"
+  status-other:
+    - "&7{player}: premium=&e{is_premium}&7, mode=&e{mode}&7, uuid=&e{uuid_online}"
+  unlink:
+    self-ok: "&ePremium link removed. Password required next login."
+    other-ok: "&e{player} premium link removed."
+    not-premium: "&7Nothing to unlink: account is not premium."
+  error:
+    no-target: "&cPlayer not found."
+    no-permission: "&cInsufficient permission."
 admin_stats_premium_header: "&b[Faskin] Premium Stats"
 admin_stats_premium_lines:
   - "&7Bypass ok: &f{OK}"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -31,16 +31,19 @@ commands:
     usage: '/faskin reload|status [player] | unlock <player> | stats | help'
     permission: 'faskin.admin'
   premium:
-    description: 'Commande premium'
-    usage: '/premium status|unlink [player]'
-    permission: 'faskin.premium'
+    description: 'Outils premium (status/unlink)'
+    usage: '/premium <status|unlink> [player]'
+    aliases: [ prem ]
+    permission: 'faskin.premium.base'
 permissions:
   faskin.register: { default: true }
   faskin.login: { default: true }
   faskin.logout: { default: true }
   faskin.changepassword: { default: true }
   faskin.admin: { default: op }
-  faskin.premium: { default: op }
-  faskin.premium.status: { default: op }
-  faskin.premium.unlink: { default: op }
+  faskin.premium.base: { default: true }
+  faskin.premium.status: { default: true }
+  faskin.premium.status.other: { default: op }
+  faskin.premium.unlink.self: { default: true }
+  faskin.premium.unlink.other: { default: op }
 


### PR DESCRIPTION
## Summary
- add /premium status and /premium unlink subcommands with async DB access
- add tab completion for premium commands and new permissions
- document premium command usage and proxy prerequisites

## Testing
- `gradle build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a0a93d577c83249c19dc62dd68d186