### PR TITLE
docs: document forwarding setup and message fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Build (shadow)
         run: gradle build --no-daemon
 
-      - name: Show version
-        run: echo "Building Faskin 0.1.1-hotfix"
+        - name: Show version
+          run: echo "Building Faskin 0.1.1-forwarding-hotfix"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Faskin-0.1.1-hotfix.jar
-          path: build/libs/*.jar
+        - name: Upload artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: Faskin-0.1.1-forwarding-hotfix.jar
+            path: build/libs/*.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [0.1.1] - hotfix
+## [0.1.1] - hotfix: forwarding + messages.yml
 - Auto-migrations SQLite Étape 2 exécutées au démarrage (ajout colonnes `uuid_online`, `is_premium`, `premium_verified_at`, `premium_mode`).
+- Guide proxy forwarding (Velocity/Waterfall) et messages premium complétés.
 - README : section dépannage `no such column`.
-- CI : artefact `Faskin-0.1.1-hotfix.jar`.
+- CI : artefact `Faskin-0.1.1-forwarding-hotfix.jar`.
 
 ## [0.1.0] - T2.6
 - Validation finale Étape 2 (tests, sécurité, perf, docs & CI)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Plugin unifié Spigot 1.21 / Java 21 :
 1) Auth offline (Étape 1), 2) Auto-login premium (Étape 2), 3) Skins premium en offline (Étape 3).
 
 ## Version
-`0.1.1` — hotfix auto-migrations SQLite Étape 2.
+`0.1.1` — hotfix: forwarding + messages.yml.
 
 ## Admin
 - `/faskin status [player]` : état runtime + méta compte (IP, lastLogin, compteur d’échecs, lock).
@@ -19,18 +19,50 @@ Plugin unifié Spigot 1.21 / Java 21 :
 ## Auto-login premium (Étape 2)
 Le bypass premium n’existe que si le proxy est en **online-mode** avec **player-info-forwarding** (`modern`) et un **secret** partagé. Sans cela, Faskin n’accorde aucun bypass.
 
-### Configurer le proxy
-Faskin privilégie un proxy en **online-mode** avec [player information forwarding](https://docs.papermc.io/velocity/player-information-forwarding/) activé. Cela transmet UUID, IP et propriétés signées pour un auto-login premium sécurisé. Sans forwarding, aucun bypass n'est effectué. Réfs : [FastLogin](https://www.spigotmc.org/resources/fastlogin.14153/), [discussion MITM](https://github.com/TuxCoding/FastLogin/discussions/1180).
+### Configurer Velocity/Waterfall pour l’auto-login premium
+Faskin nécessite un proxy en **online-mode** avec [player information forwarding](https://docs.papermc.io/velocity/player-information-forwarding/) pour transmettre UUID, IP et textures signées. Sans forwarding, aucun bypass n'est accordé (raison `forwarding-missing`).
 
-Exemple **Velocity** :
+#### Velocity (recommandé)
 
 ```toml
 # velocity.toml
+online-mode = true
 player-info-forwarding-mode = "modern"
-forwarding-secret = "<secret>"
+forwarding-secret-file = "forwarding.secret"
 ```
 
-Le même secret doit être défini côté backend (`velocity.toml` de Paper/Waterfall). Sans forwarding **IP/UUID/properties**, Faskin refuse le bypass. Toute modification manuelle des textures via l’API `PlayerProfile.setTextures(...)` invalide la signature et désactive le mode `PROXY_SAFE`.
+Backend Paper (`config/paper-global.yml`) :
+
+```yaml
+proxies:
+  velocity:
+    enabled: true
+    online-mode: true
+    secret: "COLLER_Ici_LE_CONTENU_DU_fwd_secret"
+```
+
+* `spigot.yml` : `settings.bungeecord: false`
+* `server.properties` : `online-mode=false`
+* Redémarrer **proxy puis backend**
+* Bonus : firewall → bloquer l’accès direct au port backend
+
+#### Waterfall/BungeeCord
+
+```yaml
+# config.yml (proxy)
+ip_forward: true
+
+# spigot.yml (backend)
+settings:
+  bungeecord: true
+
+# server.properties (backend)
+online-mode=false
+```
+
+Redémarrer le proxy et le backend.
+
+Le secret de forwarding doit être identique des deux côtés. Toute modification manuelle des textures via l’API `PlayerProfile.setTextures(...)` invalide la signature et désactive le mode `PROXY_SAFE`.
 
 ## i18n & couleurs
 - `messages_locale` ou `messages.locale` pour choisir la langue (`messages.yml` / `messages_<locale>.yml`).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -136,3 +136,4 @@ _Notes sources_ :
  - [x] T2.5 — Commandes premium (status/unlink, perms)
  - [x] T2.6 — Validation finale & sécurité
   - [x] T2.HF — Auto-migrations SQLite
+  - [x] T2.FWD — Forwarding configuré

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -52,7 +52,7 @@ admin_stats_premium_lines:
 
 premium:
   checking: "&7Vérification du statut premium..."
-  bypass-ok: "&aPremium vérifié: authentification automatique réussie."
+  bypass-ok: "&aConnexion premium vérifiée. Authentifié automatiquement."
   bypass-refused: "&cBypass premium refusé: {reason}."
   reason:
     forwarding-missing: "proxy mal configuré (player-info-forwarding)."


### PR DESCRIPTION
## Summary
- fix premium French message for bypass success
- document Velocity/Waterfall forwarding configuration
- record forwarding hotfix in changelog and roadmap

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68a238435d188324bf5d2270dc2e4d40